### PR TITLE
Feat/Proxing entrypoints, initial testing class and fat build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ mvn package
 Once previous stages completed successfully to execute the application run
 
 ```bash
-java -jar target/gomoku-engine-1.0.0.jar
+java -jar target/gomoku-engine-1.0.0.jar <name-of-entry-point-class-under-src/test>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,21 @@
                     </archive>
                 </configuration>
             </plugin>
+            <!-- Maven Shade Plugin for building a fat JAR -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>3.5.0</version>
+              <executions>
+                  <execution>
+                      <phase>package</phase>
+                      <goals><goal>shade</goal></goals>
+                      <configuration>
+                          <createDependencyReducedPom>false</createDependencyReducedPom>
+                      </configuration>
+                  </execution>
+              </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Main-Class: test.StartGame
+Main-Class: test.ProxyMain
 

--- a/src/test/CompetitiveTest.java
+++ b/src/test/CompetitiveTest.java
@@ -1,0 +1,52 @@
+package test;
+
+import org.apache.commons.cli.*;
+
+public class CompetitiveTest {
+    public static class Params {
+        public int bot1, bot2;
+        public Params() {};
+    };
+
+    private static Params ParseParams(String[] args) {
+        Options options = new Options();
+
+        Option bot1 = new Option("b1", "bot1", true, "bot id");
+        bot1.setRequired(true);
+        options.addOption(bot1);
+
+        Option bot2 = new Option("b2", "bot2", true, "bot id");
+        bot1.setRequired(true);
+        options.addOption(bot2);
+
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+        CommandLine cmd = null;//not a good practice, it serves it purpose 
+
+        try {
+            cmd = parser.parse(options, args);
+        } catch (ParseException e) {
+            System.out.println(e.getMessage());
+            formatter.printHelp("utility-name", options);
+
+            System.exit(1);
+        }
+
+        Params params = new Params();
+        try {
+            params.bot1 = Integer.parseInt(cmd.getOptionValue("bot1"));
+            params.bot2 = Integer.parseInt(cmd.getOptionValue("bot2"));
+        } catch (NumberFormatException e) {    
+            System.out.print(e.getMessage());
+            System.exit(1);
+        }
+
+        return params;
+    }
+    public static void main(String[] args) throws Exception {
+        Params params = ParseParams(args);
+
+        
+
+    }
+}

--- a/src/test/CompetitiveTest.java
+++ b/src/test/CompetitiveTest.java
@@ -16,7 +16,7 @@ public class CompetitiveTest {
         options.addOption(bot1);
 
         Option bot2 = new Option("b2", "bot2", true, "bot id");
-        bot1.setRequired(true);
+        bot2.setRequired(true);
         options.addOption(bot2);
 
         CommandLineParser parser = new DefaultParser();

--- a/src/test/ProxyMain.java
+++ b/src/test/ProxyMain.java
@@ -1,0 +1,33 @@
+package test;
+
+import java.util.Arrays;
+
+public class ProxyMain {
+
+    public static void main(String[] args) throws Exception{
+        String[] newArgs;
+
+        if(args.length == 0) {
+            return;
+        } else if(args.length > 1) {
+            newArgs = Arrays.copyOfRange(args, 1, args.length-1);
+        } else {
+            newArgs = new String[0];
+        }
+
+        switch (args[0]) {
+            case "AgentAnalysis":
+                AgentAnalysis.main(newArgs);
+                break;
+            case "CompetitiveTest":
+                CompetitiveTest.main(newArgs);
+                break;
+            case "StartGame":
+                StartGame.main(newArgs);
+                break;
+            case "TestMonte":
+                TestMonte.main(newArgs);
+                break;
+        }
+    }
+}


### PR DESCRIPTION
Implement Proxy class for running different entry points and initial custom testing class.

Additionally pom.xml has been extended to prepare `fat .jar` instead of regular `.jar`, as to workaround linking issues during runtime.